### PR TITLE
Fix serializing optional inner values as bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "base64"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.114"
-base64 = "0.12.2"
+serde = "1.0.117"
+base64 = "0.13.0"
 hex = "0.4.2"
 
 [dev-dependencies]
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { version = "1.0.117", features = ["derive"] }
 serde_bytes = "0.11.5"
-serde_json = "1.0.55"
+serde_json = "1.0.59"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,25 @@
 //! # Serde adapter for (de)serializing bytes to and from specific formats
 //!
 //! Currently these representations is supported:
-//! 
+//!
 //! - Base64
 //! - Hexidecimal
-//! 
+//!
 //! Human readable formats tend not to include a universally agreed way to represent arbitrary binary
 //! data, which means those serde libraries can end up using a representation for serde's "bytes" type
 //! which isn't ideal for all uses. This library gives you the option to choose a different
 //! representation than the default for libraries like `serde_json`, `toml` and `serde_yaml`.
-//! 
+//!
 //! ## How to make sure that your datatype is interpreted as bytes?
 //!
 //! Without specialization, Rust forces Serde to treat &[u8] just like any other
 //! slice and Vec<u8> just like any other vector. To enable specialized handling
 //! of `&[u8]` can use the [serde_bytes](https://docs.rs/serde_bytes/0.11.5/serde_bytes/index.html) crate.
-//! 
+//!
 //! You'll se this in use in the examples below:
-//! 
+//!
 //! ## Serialization
-//! 
+//!
 //! ```rust
 //! use serde::{Deserialize, Serialize};
 //! use serde_bytes_repr::ByteFmtSerializer;
@@ -31,20 +31,20 @@
 //!     }
 //!     let bytes = b"testing".to_vec();
 //!     let demo = Demo { bytes };
-//! 
+//!
 //!     let mut out = vec![];
 //!     let mut ser = serde_json::Serializer::new(&mut out);
 //!     let base64_config = base64::Config::new(base64::CharacterSet::UrlSafe, true);
 //!     let ser = ByteFmtSerializer::base64(&mut ser, base64_config);
 //!     demo.serialize(ser).unwrap();
-//! 
+//!
 //!     let serialized = String::from_utf8(out).unwrap();
 //!     assert_eq!(r#"{"bytes":"dGVzdGluZw=="}"#, serialized.as_str());
 //! # }
 //! ```
-//! 
+//!
 //! ## Deserialization
-//! 
+//!
 //! ```rust
 //! use serde::{Deserialize, Serialize};
 //! use serde_bytes_repr::{ByteFmtDeserializer, ByteFmtSerializer};
@@ -54,13 +54,13 @@
 //!         #[serde(with = "serde_bytes")]
 //!         bytes: Vec<u8>,
 //!     }
-//! 
+//!
 //!     let json = br#"{"bytes":"dGVzdGluZw=="}"#;
 //!     let mut json_de = serde_json::Deserializer::from_slice(json);
 //!     let base64_config = base64::Config::new(base64::CharacterSet::UrlSafe, true);
 //!     let bytefmt_json_de = ByteFmtDeserializer::new_base64(&mut json_de, base64_config);
 //!     let demo: Demo = Demo::deserialize(bytefmt_json_de).unwrap();
-//! 
+//!
 //!     let deserialized = String::from_utf8(demo.bytes).unwrap();
 //!     assert_eq!("testing", deserialized.as_str());
 //! # }
@@ -75,7 +75,7 @@ enum ByteFormat {
     Hex,
 }
 
-/// Serializer-adapter which encodes bytes to using the specified encoding. The format is 
+/// Serializer-adapter which encodes bytes to using the specified encoding. The format is
 /// serialized to the data formats string representation.
 pub struct ByteFmtSerializer<S> {
     inner: S,

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -96,7 +96,7 @@ impl<S: Serializer> Serializer for ByteFmtSerializer<S> {
     where
         T: Serialize,
     {
-        S::serialize_some(self.inner, value)
+        value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -58,3 +58,48 @@ fn serialize_seq_hex() {
     let deserialized = String::from_utf8(bytes.to_vec()).unwrap();
     assert_eq!("testing", deserialized.as_str());
 }
+
+#[test]
+fn deserialize_option_base64() {
+    #[derive(Serialize, Deserialize)]
+    struct Demo {
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct OptionWrapper {
+        demo: Option<Demo>,
+    }
+
+    let json = br#"{"demo":{"bytes":"dGVzdGluZw=="}}"#;
+    let mut json_de = serde_json::Deserializer::from_slice(json);
+    let base64_config = base64::Config::new(base64::CharacterSet::UrlSafe, true);
+    let bytefmt_json_de = ByteFmtDeserializer::new_base64(&mut json_de, base64_config);
+    let option_wrapper: OptionWrapper = OptionWrapper::deserialize(bytefmt_json_de).unwrap();
+
+    let deserialized = String::from_utf8(option_wrapper.demo.unwrap().bytes).unwrap();
+    assert_eq!("testing", deserialized.as_str());
+}
+
+#[test]
+fn deserialize_option_hex() {
+    #[derive(Serialize, Deserialize)]
+    struct Demo {
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct OptionWrapper {
+        demo: Option<Demo>,
+    }
+
+    let json = br#"{"demo":{"bytes":"74657374696e67"}}"#;
+    let mut json_de = serde_json::Deserializer::from_slice(json);
+    let bytefmt_json_de = ByteFmtDeserializer::new_hex(&mut json_de);
+    let option_wrapper: OptionWrapper = OptionWrapper::deserialize(bytefmt_json_de).unwrap();
+
+    let deserialized = String::from_utf8(option_wrapper.demo.unwrap().bytes).unwrap();
+    assert_eq!("testing", deserialized.as_str());
+}

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -68,3 +68,42 @@ fn serialize_seq_hex() {
     let serialized = String::from_utf8(out).unwrap();
     assert_eq!(r#""74657374696e67""#, serialized.as_str());
 }
+
+#[test]
+fn serialize_option_base64() {
+    #[derive(Serialize, Deserialize)]
+    struct Demo {
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    }
+    let bytes = b"testing".to_vec();
+    let demo = Some(Demo { bytes });
+
+    let mut out = vec![];
+    let mut ser = serde_json::Serializer::new(&mut out);
+    let base64_config = base64::Config::new(base64::CharacterSet::UrlSafe, true);
+    let ser = ByteFmtSerializer::base64(&mut ser, base64_config);
+    demo.serialize(ser).unwrap();
+
+    let serialized = String::from_utf8(out).unwrap();
+    assert_eq!(r#"{"bytes":"dGVzdGluZw=="}"#, serialized.as_str());
+}
+
+#[test]
+fn serialize_option_hex() {
+    #[derive(Serialize, Deserialize)]
+    struct Demo {
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    }
+    let bytes = b"testing".to_vec();
+    let demo = Some(Demo { bytes });
+
+    let mut out = vec![];
+    let mut ser = serde_json::Serializer::new(&mut out);
+    let ser = ByteFmtSerializer::hex(&mut ser);
+    demo.serialize(ser).unwrap();
+
+    let serialized = String::from_utf8(out).unwrap();
+    assert_eq!(r#"{"bytes":"74657374696e67"}"#, serialized.as_str());
+}


### PR DESCRIPTION
Optional structs don't serialize inner values as strings. Fix calls to the serialize method of the type instead of passing to the other Serializer implementation.